### PR TITLE
Change galaxy points from circular to linear layout

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -275,6 +275,204 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     shipPosRef.current = shipPosition;
   }, [shipPosition]);
 
+  // Sistema de geração de estrelas cadentes
+  const createShootingStar = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return null;
+
+    const colors = [
+      "#60A5FA", // Blue
+      "#F87171", // Red
+      "#34D399", // Green
+      "#FBBF24", // Yellow
+      "#A78BFA", // Purple
+      "#FB7185", // Pink
+      "#10B981", // Emerald
+      "#F59E0B", // Amber
+      "#8B5CF6", // Violet
+      "#06B6D4", // Cyan
+    ];
+
+    // Propriedades aleatórias para cada estrela cadente
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 2 + Math.random() * 4; // Velocidade entre 2-6
+    const size = 0.8 + Math.random() * 1.2; // Tamanho entre 0.8-2.0 (não muito grande)
+    const life = 60 + Math.random() * 120; // Vida entre 1-3 segundos a 60fps
+    const tailLength = 15 + Math.random() * 25; // Comprimento da cauda
+
+    // Posição inicial fora da tela
+    const margin = 100;
+    let startX, startY;
+
+    const side = Math.floor(Math.random() * 4);
+    switch (side) {
+      case 0: // Top
+        startX = Math.random() * (canvas.width + 2 * margin) - margin;
+        startY = -margin;
+        break;
+      case 1: // Right
+        startX = canvas.width + margin;
+        startY = Math.random() * (canvas.height + 2 * margin) - margin;
+        break;
+      case 2: // Bottom
+        startX = Math.random() * (canvas.width + 2 * margin) - margin;
+        startY = canvas.height + margin;
+        break;
+      default: // Left
+        startX = -margin;
+        startY = Math.random() * (canvas.height + 2 * margin) - margin;
+        break;
+    }
+
+    return {
+      x: startX,
+      y: startY,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      life: life,
+      maxLife: life,
+      size: size,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      tailLength: tailLength,
+      angle: angle,
+      startTime: Date.now(),
+    };
+  }, []);
+
+  const updateShootingStars = useCallback(
+    (currentTime: number) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      // Gera novas estrelas cadentes ocasionalmente
+      if (
+        currentTime - lastShootingStarTime.current >
+        2000 + Math.random() * 4000
+      ) {
+        const newStar = createShootingStar();
+        if (newStar) {
+          shootingStarsRef.current.push(newStar);
+          lastShootingStarTime.current = currentTime;
+        }
+      }
+
+      // Atualiza estrelas cadentes existentes
+      shootingStarsRef.current = shootingStarsRef.current.filter((star) => {
+        // Animação baseada em seno para movimento fluido
+        const timeDelta = (currentTime - star.startTime) * 0.001; // Converte para segundos
+        const sineWave = Math.sin(timeDelta * 3) * 0.3; // Ondulação suave
+
+        // Aplica movimento com ondulação
+        star.x += star.vx + sineWave * Math.cos(star.angle + Math.PI / 2);
+        star.y += star.vy + sineWave * Math.sin(star.angle + Math.PI / 2);
+
+        star.life--;
+
+        // Remove estrelas que saíram da tela ou acabou a vida
+        return (
+          star.life > 0 &&
+          star.x > -200 &&
+          star.x < canvas.width + 200 &&
+          star.y > -200 &&
+          star.y < canvas.height + 200
+        );
+      });
+    },
+    [createShootingStar],
+  );
+
+  const renderShootingStars = useCallback(
+    (ctx: CanvasRenderingContext2D, currentTime: number) => {
+      shootingStarsRef.current.forEach((star) => {
+        const opacity = (star.life / star.maxLife) * 0.9;
+        const timeDelta = (currentTime - star.startTime) * 0.001;
+
+        // Animação de tamanho baseada em seno
+        const sizeVariation = 1 + Math.sin(timeDelta * 8) * 0.2; // Pulso suave
+        const currentSize = star.size * sizeVariation;
+
+        // Desenha a cauda da estrela cadente
+        const tailPoints = [];
+        for (let i = 0; i < star.tailLength; i++) {
+          const progress = i / star.tailLength;
+          const tailOpacity = opacity * (1 - progress) * 0.7;
+
+          tailPoints.push({
+            x: star.x - star.vx * progress * 3,
+            y: star.y - star.vy * progress * 3,
+            opacity: tailOpacity,
+            size: currentSize * (1 - progress * 0.8),
+          });
+        }
+
+        // Renderiza a cauda
+        tailPoints.forEach((point, index) => {
+          if (point.opacity > 0.01) {
+            const gradient = ctx.createRadialGradient(
+              point.x,
+              point.y,
+              0,
+              point.x,
+              point.y,
+              point.size * 3,
+            );
+            gradient.addColorStop(
+              0,
+              star.color +
+                Math.floor(point.opacity * 255)
+                  .toString(16)
+                  .padStart(2, "0"),
+            );
+            gradient.addColorStop(
+              0.6,
+              star.color +
+                Math.floor(point.opacity * 128)
+                  .toString(16)
+                  .padStart(2, "0"),
+            );
+            gradient.addColorStop(1, star.color + "00");
+
+            ctx.globalAlpha = point.opacity;
+            ctx.fillStyle = gradient;
+            ctx.beginPath();
+            ctx.arc(point.x, point.y, point.size * 3, 0, Math.PI * 2);
+            ctx.fill();
+          }
+        });
+
+        // Desenha o núcleo brilhante da estrela
+        const coreGradient = ctx.createRadialGradient(
+          star.x,
+          star.y,
+          0,
+          star.x,
+          star.y,
+          currentSize * 4,
+        );
+        coreGradient.addColorStop(0, "#FFFFFF");
+        coreGradient.addColorStop(0.3, star.color);
+        coreGradient.addColorStop(0.7, star.color + "88");
+        coreGradient.addColorStop(1, star.color + "00");
+
+        ctx.globalAlpha = opacity;
+        ctx.fillStyle = coreGradient;
+        ctx.beginPath();
+        ctx.arc(star.x, star.y, currentSize * 4, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Núcleo interno brilhante
+        ctx.globalAlpha = opacity * 0.9;
+        ctx.fillStyle = "#FFFFFF";
+        ctx.beginPath();
+        ctx.arc(star.x, star.y, currentSize, 0, Math.PI * 2);
+        ctx.fill();
+      });
+
+      ctx.globalAlpha = 1;
+    },
+    [],
+  );
+
   // Geração dinâmica de estrelas baseada na posição da câmera
   const renderStarsCanvas = useCallback(() => {
     const canvas = canvasRef.current;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1451,7 +1451,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   // Renderiza pontos de forma otimizada
   const renderPoints = () => {
     return GALAXY_POINTS.map((point) => (
-      <div key={point.id} className="pointer-events-auto">
+      <div key={point.id} className="pointer-events-auto relative z-30">
         <MapPoint
           point={point}
           isNearby={nearbyPoint === point.id}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -296,9 +296,9 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     // Propriedades aleatórias para cada estrela cadente
     const angle = Math.random() * Math.PI * 2;
     const speed = 2 + Math.random() * 4; // Velocidade entre 2-6
-    const size = 0.8 + Math.random() * 1.2; // Tamanho entre 0.8-2.0 (não muito grande)
+    const size = 0.4 + Math.random() * 0.6; // Tamanho entre 0.4-1.0 (menores)
     const life = 60 + Math.random() * 120; // Vida entre 1-3 segundos a 60fps
-    const tailLength = 15 + Math.random() * 25; // Comprimento da cauda
+    const tailLength = 12 + Math.random() * 18; // Comprimento da cauda (reduzido)
 
     // Posição inicial fora da tela
     const margin = 100;

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1547,7 +1547,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
       {/* Área de drag fixa - sempre cobre toda a tela */}
       <div
-        className={`absolute inset-0 z-10 ${isDragging ? "cursor-grabbing" : isAutoPilot ? "cursor-pointer" : "cursor-grab"}`}
+        className={`absolute inset-0 z-5 ${isDragging ? "cursor-grabbing" : isAutoPilot ? "cursor-pointer" : "cursor-grab"}`}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -116,7 +116,7 @@ const generateLinearPoints = () => {
   });
 };
 
-const GALAXY_POINTS: MapPointData[] = generateCircularPoints();
+const GALAXY_POINTS: MapPointData[] = generateLinearPoints();
 
 export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   const [shipPosition, setShipPosition] = useState(() => {
@@ -148,7 +148,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   const mapY = useMotionValue(0);
   const shipRotation = useMotionValue(0);
 
-  // Sistema de rotaç��o suave
+  // Sistema de rotação suave
   const targetRotation = useRef(0);
   const lastRotationUpdate = useRef(0);
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -384,11 +384,11 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   const renderShootingStars = useCallback(
     (ctx: CanvasRenderingContext2D, currentTime: number) => {
       shootingStarsRef.current.forEach((star) => {
-        const opacity = (star.life / star.maxLife) * 0.9;
+        const opacity = Math.min(1, (star.life / star.maxLife) * 1.2); // Mais luminosas
         const timeDelta = (currentTime - star.startTime) * 0.001;
 
         // Animação de tamanho baseada em seno
-        const sizeVariation = 1 + Math.sin(timeDelta * 8) * 0.2; // Pulso suave
+        const sizeVariation = 1 + Math.sin(timeDelta * 8) * 0.3; // Pulso mais intenso
         const currentSize = star.size * sizeVariation;
 
         // Desenha a cauda da estrela cadente

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -1600,7 +1600,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
           />
         </div>
         {/* Renderiza apenas uma vez */}
-        <div className="absolute inset-0">{renderPoints()}</div>
+        <div className="absolute inset-0 z-20">{renderPoints()}</div>
       </motion.div>
 
       {/* Nave do jogador - fixa no centro */}

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -655,8 +655,12 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     generateLayer(4, 0.25, 2); // Middle
     generateLayer(2, 0.5, 3); // Foreground
 
+    // Atualiza e renderiza estrelas cadentes
+    updateShootingStars(Date.now());
+    renderShootingStars(ctx, Date.now());
+
     ctx.globalAlpha = 1;
-  }, [mapX, mapY]);
+  }, [mapX, mapY, updateShootingStars, renderShootingStars]);
 
   // Sistema de animação otimizado para Canvas
   useEffect(() => {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -169,6 +169,24 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   const autoPilotAnimationRef = useRef<number>();
   const holdTimeoutRef = useRef<number>();
 
+  // Sistema de estrelas cadentes
+  const shootingStarsRef = useRef<
+    {
+      x: number;
+      y: number;
+      vx: number;
+      vy: number;
+      life: number;
+      maxLife: number;
+      size: number;
+      color: string;
+      tailLength: number;
+      angle: number;
+      startTime: number;
+    }[]
+  >([]);
+  const lastShootingStarTime = useRef(0);
+
   // Sistema de estrelas corrigido para escala -5000 a +5000
   const starData = useMemo(() => {
     const colors = [

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -675,6 +675,8 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       if (animationFrameRef.current) {
         cancelAnimationFrame(animationFrameRef.current);
       }
+      // Limpa estrelas cadentes ao desmontar
+      shootingStarsRef.current = [];
     };
   }, [renderStarsCanvas]);
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -41,8 +41,8 @@ const wrap = (value: number, min: number, max: number): number => {
   return result;
 };
 
-// Gera pontos em círculo ao redor do centro com 40px de espaçamento
-const generateCircularPoints = () => {
+// Gera pontos em linha horizontal para facilitar cliques
+const generateLinearPoints = () => {
   const points = [
     {
       id: "terra-nova",
@@ -101,19 +101,17 @@ const generateCircularPoints = () => {
     },
   ];
 
-  const centerX = 50; // Centro do mapa em %
-  const centerY = 50;
-  const radius = 6; // Raio em % para formar um círculo pequeno
+  // Arranja pontos em linha horizontal
+  const centerY = 50; // Centro vertical
+  const spacing = 80 / (points.length - 1); // Espaçamento entre 10% e 90%
 
   return points.map((point, index) => {
-    const angle = (index / points.length) * 2 * Math.PI;
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
+    const x = 10 + index * spacing; // Distribui de 10% a 90%
 
     return {
       ...point,
-      x: Math.max(5, Math.min(95, x)), // Limita entre 5% e 95%
-      y: Math.max(5, Math.min(95, y)),
+      x: x,
+      y: centerY,
     };
   });
 };
@@ -150,7 +148,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
   const mapY = useMotionValue(0);
   const shipRotation = useMotionValue(0);
 
-  // Sistema de rotação suave
+  // Sistema de rotaç��o suave
   const targetRotation = useRef(0);
   const lastRotationUpdate = useRef(0);
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -447,24 +447,24 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
           0,
           star.x,
           star.y,
-          currentSize * 4,
+          currentSize * 5,
         );
         coreGradient.addColorStop(0, "#FFFFFF");
-        coreGradient.addColorStop(0.3, star.color);
-        coreGradient.addColorStop(0.7, star.color + "88");
+        coreGradient.addColorStop(0.2, star.color);
+        coreGradient.addColorStop(0.5, star.color + "BB");
         coreGradient.addColorStop(1, star.color + "00");
 
-        ctx.globalAlpha = opacity;
+        ctx.globalAlpha = Math.min(1, opacity * 1.3);
         ctx.fillStyle = coreGradient;
         ctx.beginPath();
-        ctx.arc(star.x, star.y, currentSize * 4, 0, Math.PI * 2);
+        ctx.arc(star.x, star.y, currentSize * 5, 0, Math.PI * 2);
         ctx.fill();
 
-        // Núcleo interno brilhante
-        ctx.globalAlpha = opacity * 0.9;
+        // Núcleo interno mais brilhante
+        ctx.globalAlpha = Math.min(1, opacity * 1.5);
         ctx.fillStyle = "#FFFFFF";
         ctx.beginPath();
-        ctx.arc(star.x, star.y, currentSize, 0, Math.PI * 2);
+        ctx.arc(star.x, star.y, currentSize * 1.2, 0, Math.PI * 2);
         ctx.fill();
       });
 


### PR DESCRIPTION
Changes the galaxy map point layout from circular arrangement to horizontal linear arrangement.

Key changes:
- Renamed `generateCircularPoints()` to `generateLinearPoints()`
- Updated point positioning logic to distribute points horizontally from 10% to 90% width
- Removed circular positioning calculations (angle, radius, trigonometric functions)
- Added shooting star animation system with particle effects and trails
- Updated z-index values for proper layering of interactive elements
- Added shooting star lifecycle management and cleanup on component unmount

The linear layout positions all galaxy points in a horizontal line at 50% vertical position, making them easier to click and interact with.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b81d8f483dd34efebee036fb46fcb9f2/curry-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b81d8f483dd34efebee036fb46fcb9f2</projectId>-->
<!--<branchName>curry-oasis</branchName>-->